### PR TITLE
feat: Add RentalAsset entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Decentraland Rentals graph
 
-- Mainnet: https://thegraph.com/hosted-service/subgraph/decentraland/rentals-ethereum-mainnet (not-deployed-yet)
-- Goerli: https://thegraph.com/hosted-service/subgraph/decentraland/rentals-ethereum-goerli (QmShZDySTjnaaWPWUy4idSenpgpH8UA5ETdKeknYiJot1r)
+- Mainnet: https://thegraph.com/hosted-service/subgraph/decentraland/rentals-ethereum-mainnet
+  - Prev: `-`
+  - Curr: `-`
+- Goerli: https://thegraph.com/hosted-service/subgraph/decentraland/rentals-ethereum-goerli
+  - Prev: `QmZB47XmHajLtzSCzkNE6uaPJTMUuYTuC7JeDxJzWFxcjj`
+  - Curr: `Qmep2pNEhT8BJJiDLVS38HizP4aX92VFVmM5rHSo8hRf69`
 
 ### Install
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -76,6 +76,6 @@ type RentalAsset @entity {
   tokenId: BigInt!
   # The address acting as lessor of the asset, will be null if the asset was claimed back.
   lessor: Bytes
-  # Determines if the asset has been transferred out of the rentals contract though a claim.
+  # Determines if the asset has been transferred out of the rentals contract through a claim.
   isClaimed: Boolean!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -68,3 +68,14 @@ type IndexesUpdateAssetHistory @entity {
 type Rentable @entity {
   id: ID!
 }
+
+# Assets that have been transferred in and out of the rentals contract.
+type RentalAsset @entity {
+  id: ID!
+  contractAddress: Bytes!
+  tokenId: BigInt!
+  # The address acting as lessor of the asset, will be null if the asset was claimed back.
+  lessor: Bytes
+  # Determines if the asset has been transferred out of the rentals contract though a claim.
+  isClaimed: Boolean!
+}

--- a/src/entities/schema.ts
+++ b/src/entities/schema.ts
@@ -554,3 +554,79 @@ export class Rentable extends Entity {
     this.set("id", Value.fromString(value));
   }
 }
+
+export class RentalAsset extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id != null, "Cannot save RentalAsset entity without an ID");
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        `Entities of type RentalAsset must have an ID of type String but the id '${id.displayData()}' is of type ${id.displayKind()}`
+      );
+      store.set("RentalAsset", id.toString(), this);
+    }
+  }
+
+  static load(id: string): RentalAsset | null {
+    return changetype<RentalAsset | null>(store.get("RentalAsset", id));
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value!.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get contractAddress(): Bytes {
+    let value = this.get("contractAddress");
+    return value!.toBytes();
+  }
+
+  set contractAddress(value: Bytes) {
+    this.set("contractAddress", Value.fromBytes(value));
+  }
+
+  get tokenId(): BigInt {
+    let value = this.get("tokenId");
+    return value!.toBigInt();
+  }
+
+  set tokenId(value: BigInt) {
+    this.set("tokenId", Value.fromBigInt(value));
+  }
+
+  get lessor(): Bytes | null {
+    let value = this.get("lessor");
+    if (!value || value.kind == ValueKind.NULL) {
+      return null;
+    } else {
+      return value.toBytes();
+    }
+  }
+
+  set lessor(value: Bytes | null) {
+    if (!value) {
+      this.unset("lessor");
+    } else {
+      this.set("lessor", Value.fromBytes(<Bytes>value));
+    }
+  }
+
+  get isClaimed(): boolean {
+    let value = this.get("isClaimed");
+    return value!.toBoolean();
+  }
+
+  set isClaimed(value: boolean) {
+    this.set("isClaimed", Value.fromBoolean(value));
+  }
+}

--- a/src/handlers/rentals.ts
+++ b/src/handlers/rentals.ts
@@ -10,6 +10,7 @@ import {
   IndexesUpdateSignerHistory,
   Rental,
   Rentable,
+  RentalAsset,
 } from '../entities/schema'
 import { AssetRented, AssetClaimed, ContractIndexUpdated, SignerIndexUpdated, AssetIndexUpdated } from '../entities/Rentals/Rentals'
 import { Rentable as RentableTemplate } from '../entities/templates'
@@ -61,12 +62,28 @@ export function handleAssetRented(event: AssetRented): void {
   metric.save()
 
   let rentable = Rentable.load(contractAddress)
-  
+
   if (rentable == null) {
     RentableTemplate.create(Address.fromString(contractAddress))
     rentable = new Rentable(contractAddress)
     rentable.save()
   }
+
+  // RentalAsset
+
+  let rentalAssetId = contractAddress + '-' + tokenId.toString()
+  let rentalAsset = RentalAsset.load(rentalAssetId)
+
+  if (rentalAsset == null) {
+    rentalAsset = new RentalAsset(rentalAssetId)
+  }
+
+  rentalAsset.contractAddress = Address.fromHexString(contractAddress)
+  rentalAsset.tokenId = tokenId
+  rentalAsset.lessor = Address.fromHexString(rental.lessor)
+  rentalAsset.isClaimed = false
+
+  rentalAsset.save()
 }
 
 export function handleAssetClaimed(event: AssetClaimed): void {
@@ -85,6 +102,18 @@ export function handleAssetClaimed(event: AssetClaimed): void {
   rental.ownerHasClaimedAsset = true
   rental.updatedAt = event.block.timestamp
   rental.save()
+
+  let rentalAssetId = contractAddress + '-' + tokenId.toString()
+  let rentalAsset = RentalAsset.load(rentalAssetId)
+
+  if (rentalAsset == null) {
+    console.error('RentalAsset with id "{}" does not exist', [rentalAssetId])
+  } else {
+    rentalAsset.lessor = null
+    rentalAsset.isClaimed = true
+
+    rentalAsset.save()
+  }
 }
 
 export function handleContractIndexUpdated(event: ContractIndexUpdated): void {

--- a/src/handlers/rentals.ts
+++ b/src/handlers/rentals.ts
@@ -107,7 +107,7 @@ export function handleAssetClaimed(event: AssetClaimed): void {
   let rentalAsset = RentalAsset.load(rentalAssetId)
 
   if (rentalAsset == null) {
-    console.error('RentalAsset with id "{}" does not exist', [rentalAssetId])
+    log.error('RentalAsset with id "{}" does not exist', [rentalAssetId])
   } else {
     rentalAsset.lessor = null
     rentalAsset.isClaimed = true


### PR DESCRIPTION
I need to obtain assets that have belonged to a certain address before being transferred to the rentals contract.

The queries that I need to make are:

"Give me the LANDs/Estates that are currently in the Rentals contract that belonged to these addresses"

My solution to this in order to make it as easy as possible is to query the RentalAssets with something like:

```
{
    rentalAssets(
        where: {
            lessor_in: [addresses], 
            contractAddress_in: [landAddress, estateAddress], 
            isClaimed: false
        }) {
        contractAddress
        lessor
    }
}
```